### PR TITLE
feat: bigint support and constraints uniformisation

### DIFF
--- a/packages/ts-predicate/docs/TypeAssertion.md
+++ b/packages/ts-predicate/docs/TypeAssertion.md
@@ -102,7 +102,7 @@ using Object prototype.
 
 Symbol keys are ignored when validating record items.
 
-The optional parameter `constraints` accept an object described as below.
+The optional parameter `constraints` accepts an object described as below.
 
 ```ts
 interface RecordConstraints<T>

--- a/packages/ts-predicate/docs/TypeAssertion.md
+++ b/packages/ts-predicate/docs/TypeAssertion.md
@@ -40,6 +40,14 @@ isFiniteNumber(value: unknown): void
 
 Asserts that the value is a number, but not NaN nor +/-Infinity.
 
+## IsBigInt
+
+```ts
+isBigInt(value: unknown): void
+```
+
+Asserts that the value is a big integer.
+
 ## IsString
 
 ```ts
@@ -51,7 +59,7 @@ Asserts that the value is a string.
 ## IsArray
 
 ```ts
-isArray(value: unknown, constraints?: ArrayConstraints): void
+isArray(value: unknown, constraints?: ArrayConstraints | Test): void
 ```
 
 Asserts that the value is an array.
@@ -62,10 +70,10 @@ The optional parameter `constraints` accept an object described as below.
 interface ArrayConstraints<T>
 {
 	minLength?: number;
-	itemTest?: ItemTest<T>;
+	itemTest?: Test<T>;
 }
 
-type ItemTest<T> =
+type Test<T> =
 	| (item: unknown) => asserts item is T
 	| (item: unknown) => item is T
 ;
@@ -78,7 +86,7 @@ If `itemTest` is provided, it'll asserts that the predicate hold true for every 
 ## IsPopulatedArray
 
 ```ts
-isPopulatedArray(value: unknown, constraints?: ArrayConstraints): void
+isPopulatedArray(value: unknown, constraints?: ArrayConstraints | Test): void
 ```
 
 Like `isArray`, but asserts that the array is never empty too.
@@ -86,7 +94,7 @@ Like `isArray`, but asserts that the array is never empty too.
 ## IsRecord
 
 ```ts
-isRecord(value: unknown, item_test?: ItemTest<T>): void
+isRecord(value: unknown, constraints?: RecordConstraints | Test): void
 ```
 
 Asserts that the value is a record: an object with no prototype, or directly
@@ -94,14 +102,21 @@ using Object prototype.
 
 Symbol keys are ignored when validating record items.
 
-If `item_test` is provided, it'll asserts that the predicate hold true for every item.
+The optional parameter `constraints` accept an object described as below.
 
 ```ts
-type ItemTest<T> =
+interface RecordConstraints<T>
+{
+	itemTest?: Test<T>;
+}
+
+type Test<T> =
 	| (item: unknown) => asserts item is T
 	| (item: unknown) => item is T
 ;
 ```
+
+If `itemTest` is provided, it'll asserts that the predicate hold true for every item.
 
 ## IsObject
 

--- a/packages/ts-predicate/docs/TypeGuard.md
+++ b/packages/ts-predicate/docs/TypeGuard.md
@@ -72,7 +72,7 @@ isArray(value: unknown, constraints?: ArrayConstraints | Test): boolean
 
 Narrow down the value to being an array.
 
-The optional parameter `constraints` accept an object described by the following interface.
+The optional parameter `constraints` accepts an object described by the following interface.
 
 ```ts
 interface ArrayConstraints<T>
@@ -109,7 +109,7 @@ Narrow down the value to being a record: an object with no prototype, or directl
 
 Symbol keys are ignored when validating record items.
 
-The optional parameter `constraints` accept an object described by the following interface.
+The optional parameter `constraints` accepts an object described by the following interface.
 
 ```ts
 interface RecordConstraints<T>

--- a/packages/ts-predicate/docs/TypeGuard.md
+++ b/packages/ts-predicate/docs/TypeGuard.md
@@ -48,6 +48,14 @@ isFiniteNumber(value: unknown): boolean
 
 Narrow down the value to being a number, but not NaN nor +/-Infinity.
 
+## IsBigInt
+
+```ts
+isBigInt(value: unknown): boolean
+```
+
+Narrow down the value to being a big integer.
+
 ## IsString
 
 ```ts
@@ -59,7 +67,7 @@ Narrow down the value to being a string.
 ## IsArray
 
 ```ts
-isArray(value: unknown, constraints?: ArrayConstraints): boolean
+isArray(value: unknown, constraints?: ArrayConstraints | Test): boolean
 ```
 
 Narrow down the value to being an array.
@@ -70,10 +78,10 @@ The optional parameter `constraints` accept an object described by the following
 interface ArrayConstraints<T>
 {
 	minLength?: number;
-	itemTest?: (item: unknown) => item is T;
+	itemTest?: Test<T>;
 }
 
-type ItemTest<T> =
+type Test<T> =
 	| (item: unknown) => asserts item is T
 	| (item: unknown) => item is T
 ;
@@ -86,7 +94,7 @@ If `itemTest` is provided, it'll confirm that the predicate hold true for every 
 ## IsPopulatedArray
 
 ```ts
-isPopulatedArray(value: unknown, constraints?: ArrayConstraints): boolean
+isPopulatedArray(value: unknown, constraints?: ArrayConstraints | Test): boolean
 ```
 
 Like `IsArray`, but narrow it to being a populated array.
@@ -94,21 +102,28 @@ Like `IsArray`, but narrow it to being a populated array.
 ## IsRecord
 
 ```ts
-isRecord(value: unknown, item_test?: ItemTest<T>): boolean
+isRecord(value: unknown, constraints?: RecordConstraints | Test): boolean
 ```
 
 Narrow down the value to being a record: an object with no prototype, or directly using Object prototype.
 
 Symbol keys are ignored when validating record items.
 
-If `item_test` is provided, it'll confirm that the predicate hold true for every item.
+The optional parameter `constraints` accept an object described by the following interface.
 
 ```ts
-type ItemTest<T> =
+interface RecordConstraints<T>
+{
+	itemTest?: Test<T>;
+}
+
+type Test<T> =
 	| (item: unknown) => asserts item is T
 	| (item: unknown) => item is T
 ;
 ```
+
+If `itemTest` is provided, it'll confirm that the predicate hold true for every item.
 
 ## IsObject
 

--- a/packages/ts-predicate/docs/TypeHint.md
+++ b/packages/ts-predicate/docs/TypeHint.md
@@ -15,6 +15,7 @@ Possible values:
 - NaN
 - boolean
 - number
+- bigint
 - string
 - array
 - object
@@ -40,6 +41,7 @@ Possible values:
 - NaN
 - boolean (true or false)
 - number (N)
+- bigint (N)
 - string (N characters)
 - array (N items)
 - anonymous object

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-lab/ts-predicate",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "TypeScript predicates library",
 	"author": "Benjamin Blum <benjamin.blum.98@gmail.com>",
 	"contributors": [

--- a/packages/ts-predicate/src/TypeAssertion/_index.mts
+++ b/packages/ts-predicate/src/TypeAssertion/_index.mts
@@ -2,6 +2,7 @@ export * from "./hasAllowedKeys.mjs";
 export * from "./hasNullableProperty.mjs";
 export * from "./hasProperty.mjs";
 export * from "./isArray.mjs";
+export * from "./isBigInt.mjs";
 export * from "./isBoolean.mjs";
 export * from "./isCallable.mjs";
 export * from "./isDefined.mjs";

--- a/packages/ts-predicate/src/TypeAssertion/isArray.mts
+++ b/packages/ts-predicate/src/TypeAssertion/isArray.mts
@@ -1,29 +1,32 @@
 import { isArray as guard } from "../TypeGuard/isArray.mjs";
 
+import { buildArrayConstraints } from "../utils/buildArrayConstraints.mjs";
+
 import { buildError } from "./utils/buildError.mjs";
 
 import { itemAssertion } from "./utils/itemAssertion.mjs";
 
 import type { ArrayConstraints, Test } from "../types/_index.mjs";
 
-
-function isArray<Type>(value: unknown, constraints?: ArrayConstraints<Type>): asserts value is Array<Type>
+function isArray<Type>(value: unknown, constraints?: ArrayConstraints<Type> | Test<Type>): asserts value is Array<Type>
 {
 	if (!guard(value))
 	{
 		throw new Error("The value is not an array.");
 	}
 
-	if (constraints === undefined)
+	const CONSTRAINTS: ArrayConstraints<Type> | undefined = buildArrayConstraints(constraints);
+
+	if (CONSTRAINTS === undefined)
 	{
 		return;
 	}
 
 	const ERRORS: Array<Error> = [];
 
-	if (constraints.minLength !== undefined && value.length < constraints.minLength)
+	if (CONSTRAINTS.minLength !== undefined && value.length < CONSTRAINTS.minLength)
 	{
-		if (constraints.minLength === 1)
+		if (CONSTRAINTS.minLength === 1)
 		{
 			ERRORS.push(
 				new Error("It must not be empty.")
@@ -32,14 +35,14 @@ function isArray<Type>(value: unknown, constraints?: ArrayConstraints<Type>): as
 		else
 		{
 			ERRORS.push(
-				new Error(`It must have at least ${constraints.minLength.toFixed(0)} items.`)
+				new Error(`It must have at least ${CONSTRAINTS.minLength.toFixed(0)} items.`)
 			);
 		}
 	}
 
-	if (constraints.itemTest !== undefined)
+	if (CONSTRAINTS.itemTest !== undefined)
 	{
-		const GUARD: Test<Type> = constraints.itemTest;
+		const GUARD: Test<Type> = CONSTRAINTS.itemTest;
 
 		value.forEach(
 			(item: unknown, index: number): void =>

--- a/packages/ts-predicate/src/TypeAssertion/isBigInt.mts
+++ b/packages/ts-predicate/src/TypeAssertion/isBigInt.mts
@@ -1,0 +1,11 @@
+import { isBigInt as guard } from "../TypeGuard/isBigInt.mjs";
+
+function isBigInt(value: unknown): asserts value is bigint
+{
+	if (!guard(value))
+	{
+		throw new Error("The value must be a big integer.");
+	}
+}
+
+export { isBigInt };

--- a/packages/ts-predicate/src/TypeAssertion/isPopulatedArray.mts
+++ b/packages/ts-predicate/src/TypeAssertion/isPopulatedArray.mts
@@ -1,15 +1,19 @@
+import { buildArrayConstraints } from "../utils/buildArrayConstraints.mjs";
+
 import { isArray } from "./isArray.mjs";
 
-import type { ArrayConstraints, PopulatedArray } from "../types/_index.mjs";
+import type { ArrayConstraints, PopulatedArray, Test } from "../types/_index.mjs";
 
 function isPopulatedArray<Type>(
 	value: unknown,
-	constraints?: ArrayConstraints<Type>,
+	constraints?: ArrayConstraints<Type> | Test<Type>,
 ): asserts value is PopulatedArray<Type>
 {
+	const CONSTRAINTS: ArrayConstraints<Type> | undefined = buildArrayConstraints(constraints);
+
 	isArray(value, {
 		minLength: 1,
-		...constraints,
+		...CONSTRAINTS,
 	});
 }
 

--- a/packages/ts-predicate/src/TypeAssertion/isPrimitive.mts
+++ b/packages/ts-predicate/src/TypeAssertion/isPrimitive.mts
@@ -1,11 +1,8 @@
-function isPrimitive(value: unknown): asserts value is boolean | number | string | null | undefined
-{
-	if (value === null)
-	{
-		return;
-	}
+import { isPrimitive as guard } from "../TypeGuard/isPrimitive.mjs";
 
-	if (typeof value === "object" || typeof value === "function" || typeof value === "symbol")
+function isPrimitive(value: unknown): asserts value is bigint | boolean | number | string | null | undefined
+{
+	if (!guard(value))
 	{
 		throw new Error("The value must be a primitive type.");
 	}

--- a/packages/ts-predicate/src/TypeAssertion/isRecord.mts
+++ b/packages/ts-predicate/src/TypeAssertion/isRecord.mts
@@ -1,21 +1,32 @@
 import { isRecord as guard } from "../TypeGuard/isRecord.mjs";
 
+import { buildRecordConstraints } from "../utils/buildRecordConstraints.mjs";
+
 import { buildError } from "./utils/buildError.mjs";
 
 import { itemAssertion } from "./utils/itemAssertion.mjs";
 
-import type { Test } from "../types/_index.mjs";
+import type { RecordConstraints, Test } from "../types/_index.mjs";
 
-function isRecord<Type>(value: unknown, item_test?: Test<Type>): asserts value is Record<string, Type>
+function isRecord<Type>(value: unknown, constraints?: RecordConstraints<Type> | Test<Type>): asserts value is Record<string, Type>
 {
 	if (!guard(value))
 	{
 		throw new Error("The value must be a record.");
 	}
 
-	if (item_test !== undefined)
+	const CONSTRAINTS: RecordConstraints<Type> | undefined = buildRecordConstraints(constraints);
+
+	if (CONSTRAINTS === undefined)
+	{
+		return;
+	}
+
+	if (CONSTRAINTS.itemTest !== undefined)
 	{
 		const ERRORS: Array<Error> = [];
+
+		const GUARD: Test<Type> = CONSTRAINTS.itemTest;
 
 		Object.keys(value).forEach(
 			(key: string): void =>
@@ -24,7 +35,7 @@ function isRecord<Type>(value: unknown, item_test?: Test<Type>): asserts value i
 				{
 					const VALUE: unknown = value[key];
 
-					itemAssertion(VALUE, item_test);
+					itemAssertion(VALUE, GUARD);
 				}
 				catch (error: unknown)
 				{

--- a/packages/ts-predicate/src/TypeGuard/_index.mts
+++ b/packages/ts-predicate/src/TypeGuard/_index.mts
@@ -2,6 +2,7 @@ export * from "./hasAllowedKeys.mjs";
 export * from "./hasNullableProperty.mjs";
 export * from "./hasProperty.mjs";
 export * from "./isArray.mjs";
+export * from "./isBigInt.mjs";
 export * from "./isBoolean.mjs";
 export * from "./isCallable.mjs";
 export * from "./isDefined.mjs";

--- a/packages/ts-predicate/src/TypeGuard/isArray.mts
+++ b/packages/ts-predicate/src/TypeGuard/isArray.mts
@@ -1,27 +1,31 @@
+import { buildArrayConstraints } from "../utils/buildArrayConstraints.mjs";
+
 import { itemGuard } from "./utils/itemGuard.mjs";
 
 import type { ArrayConstraints, Test } from "../types/_index.mjs";
 
-function isArray<Type>(value: unknown, constraints?: ArrayConstraints<Type>): value is Array<Type>
+function isArray<Type>(value: unknown, constraints?: ArrayConstraints<Type> | Test<Type>): value is Array<Type>
 {
 	if (!Array.isArray(value))
 	{
 		return false;
 	}
 
-	if (constraints === undefined)
+	const CONSTRAINTS: ArrayConstraints<Type> | undefined = buildArrayConstraints(constraints);
+
+	if (CONSTRAINTS === undefined)
 	{
 		return true;
 	}
 
-	if (constraints.minLength !== undefined && value.length < constraints.minLength)
+	if (CONSTRAINTS.minLength !== undefined && value.length < CONSTRAINTS.minLength)
 	{
 		return false;
 	}
 
-	if (constraints.itemTest !== undefined)
+	if (CONSTRAINTS.itemTest !== undefined)
 	{
-		const GUARD: Test<Type> = constraints.itemTest;
+		const GUARD: Test<Type> = CONSTRAINTS.itemTest;
 
 		return value.every(
 			(item: unknown): boolean =>

--- a/packages/ts-predicate/src/TypeGuard/isBigInt.mts
+++ b/packages/ts-predicate/src/TypeGuard/isBigInt.mts
@@ -1,0 +1,6 @@
+function isBigInt(value: unknown): value is bigint
+{
+	return typeof value === "bigint";
+}
+
+export { isBigInt };

--- a/packages/ts-predicate/src/TypeGuard/isPopulatedArray.mts
+++ b/packages/ts-predicate/src/TypeGuard/isPopulatedArray.mts
@@ -1,15 +1,19 @@
+import { buildArrayConstraints } from "../utils/buildArrayConstraints.mjs";
+
 import { isArray } from "./isArray.mjs";
 
-import type { ArrayConstraints, PopulatedArray } from "../types/_index.mjs";
+import type { ArrayConstraints, PopulatedArray, Test } from "../types/_index.mjs";
 
 function isPopulatedArray<Type>(
 	value: unknown,
-	constraints?: ArrayConstraints<Type>,
+	constraints?: ArrayConstraints<Type> | Test<Type>,
 ): value is PopulatedArray<Type>
 {
+	const CONSTRAINTS: ArrayConstraints<Type> | undefined = buildArrayConstraints(constraints);
+
 	return isArray(value, {
 		minLength: 1,
-		...constraints,
+		...CONSTRAINTS,
 	});
 }
 

--- a/packages/ts-predicate/src/TypeGuard/isPrimitive.mts
+++ b/packages/ts-predicate/src/TypeGuard/isPrimitive.mts
@@ -1,11 +1,11 @@
-function isPrimitive(value: unknown): value is boolean | number | string | null | undefined
+function isPrimitive(value: unknown): value is bigint | boolean | number | string | null | undefined
 {
 	if (value === null)
 	{
 		return true;
 	}
 
-	if (typeof value === "object" || typeof value === "function" || typeof value === "symbol")
+	if (["object", "function", "symbol"].includes(typeof value))
 	{
 		return false;
 	}

--- a/packages/ts-predicate/src/TypeGuard/isRecord.mts
+++ b/packages/ts-predicate/src/TypeGuard/isRecord.mts
@@ -1,10 +1,12 @@
+import { buildRecordConstraints } from "../utils/buildRecordConstraints.mjs";
+
 import { isObject } from "./isObject.mjs";
 
 import { itemGuard } from "./utils/itemGuard.mjs";
 
-import type { Test } from "../types/_index.mjs";
+import type { RecordConstraints, Test } from "../types/_index.mjs";
 
-function isRecord<Type>(value: unknown, item_test?: Test<Type>): value is Record<string, Type>
+function isRecord<Type>(value: unknown, constraints?: RecordConstraints<Type> | Test<Type>): value is Record<string, Type>
 {
 	if (!isObject(value))
 	{
@@ -18,12 +20,21 @@ function isRecord<Type>(value: unknown, item_test?: Test<Type>): value is Record
 		return false;
 	}
 
-	if (item_test !== undefined)
+	const CONSTRAINTS: RecordConstraints<Type> | undefined = buildRecordConstraints(constraints);
+
+	if (CONSTRAINTS === undefined)
 	{
+		return true;
+	}
+
+	if (CONSTRAINTS.itemTest !== undefined)
+	{
+		const GUARD: Test<Type> = CONSTRAINTS.itemTest;
+
 		return Object.values(value).every(
 			(item: unknown): boolean =>
 			{
-				return itemGuard(item, item_test);
+				return itemGuard(item, GUARD);
 			}
 		);
 	}

--- a/packages/ts-predicate/src/TypeHint/getDetailedType.mts
+++ b/packages/ts-predicate/src/TypeHint/getDetailedType.mts
@@ -98,6 +98,11 @@ function getDetailedType(value: unknown): string
 		return `number (${value.toString()})`;
 	}
 
+	if (typeof value === "bigint")
+	{
+		return `bigint (${value.toString()})`;
+	}
+
 	if (typeof value === "string")
 	{
 		return `string (${value.length.toString()} characters)`;
@@ -105,8 +110,7 @@ function getDetailedType(value: unknown): string
 
 	if (typeof value === "symbol")
 	{
-		// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- useless
-		return `symbol ${value.toString().slice(6)}`;
+		return value.toString().replace("Symbol", "symbol ");
 	}
 
 	return typeof value;

--- a/packages/ts-predicate/src/index.mts
+++ b/packages/ts-predicate/src/index.mts
@@ -1,4 +1,4 @@
-export * as Helpers from "./Helper/_index.mjs";
+export * as Helper from "./Helper/_index.mjs";
 export * as TypeAssertion from "./TypeAssertion/_index.mjs";
 export * as TypeGuard from "./TypeGuard/_index.mjs";
 export * as TypeHint from "./TypeHint/_index.mjs";

--- a/packages/ts-predicate/src/types/RecordConstraints.mts
+++ b/packages/ts-predicate/src/types/RecordConstraints.mts
@@ -1,0 +1,8 @@
+import type { Test } from "./Test.mjs";
+
+interface RecordConstraints<Type>
+{
+	itemTest?: Test<Type>;
+}
+
+export type { RecordConstraints };

--- a/packages/ts-predicate/src/types/_index.mts
+++ b/packages/ts-predicate/src/types/_index.mts
@@ -3,6 +3,7 @@ export * from "./NormalizedError.mjs";
 export * from "./ObjectWithNullableProperty.mjs";
 export * from "./ObjectWithProperty.mjs";
 export * from "./PopulatedArray.mjs";
+export * from "./RecordConstraints.mjs";
 export * from "./StructuredDataDescriptor.mjs";
 export * from "./StructuredDataPropertyDescriptor.mjs";
 export * from "./Test.mjs";

--- a/packages/ts-predicate/src/utils/buildArrayConstraints.mts
+++ b/packages/ts-predicate/src/utils/buildArrayConstraints.mts
@@ -1,0 +1,15 @@
+import type { ArrayConstraints, Test } from "../index.mjs";
+
+function buildArrayConstraints<Type>(constraints: ArrayConstraints<Type> | Test<Type> | undefined): ArrayConstraints<Type> | undefined
+{
+	if (typeof constraints === "function")
+	{
+		return {
+			itemTest: constraints
+		};
+	}
+
+	return constraints;
+}
+
+export { buildArrayConstraints };

--- a/packages/ts-predicate/src/utils/buildRecordConstraints.mts
+++ b/packages/ts-predicate/src/utils/buildRecordConstraints.mts
@@ -1,0 +1,15 @@
+import type { RecordConstraints, Test } from "../index.mjs";
+
+function buildRecordConstraints<Type>(constraints: RecordConstraints<Type> | Test<Type> | undefined): RecordConstraints<Type> | undefined
+{
+	if (typeof constraints === "function")
+	{
+		return {
+			itemTest: constraints
+		};
+	}
+
+	return constraints;
+}
+
+export { buildRecordConstraints };

--- a/packages/ts-predicate/test/TypeAssertion/isArray.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isArray.test.mts
@@ -62,13 +62,12 @@ describe(
 					isArray([1, 2, 3], { minLength: 2 });
 				};
 
-				doesNotThrow(WRAPPER_GREATER_LENGTH);
-
 				const WRAPPER_EXACT_LENGTH = (): void =>
 				{
 					isArray([1, 2, 3], { minLength: 3 });
 				};
 
+				doesNotThrow(WRAPPER_GREATER_LENGTH);
 				doesNotThrow(WRAPPER_EXACT_LENGTH);
 			}
 		);
@@ -82,13 +81,12 @@ describe(
 					isArray([], { minLength: 1 });
 				};
 
-				throws(WRAPPER_EMPTY, testError);
-
 				const WRAPPER_SMALL_LENGTH = (): void =>
 				{
 					isArray([1, 2, 3], { minLength: 4 });
 				};
 
+				throws(WRAPPER_EMPTY, testError);
 				throws(WRAPPER_SMALL_LENGTH, testError);
 			}
 		);
@@ -102,13 +100,12 @@ describe(
 					isArray([], { itemTest: isNumberTest });
 				};
 
-				doesNotThrow(WRAPPER_EMPTY);
-
 				const WRAPPER_VALID = (): void =>
 				{
 					isArray([1, 2, 3], { itemTest: isNumberTest });
 				};
 
+				doesNotThrow(WRAPPER_EMPTY);
 				doesNotThrow(WRAPPER_VALID);
 			}
 		);
@@ -120,6 +117,38 @@ describe(
 				const WRAPPER = (): void =>
 				{
 					isArray([1, 2, 3, Symbol("anomaly")], { itemTest: isNumberTest });
+				};
+
+				throws(WRAPPER, testAggregateError);
+			}
+		);
+
+		it(
+			"should return when given an array with all the values passing the test constraint",
+			(): void =>
+			{
+				const WRAPPER_EMPTY = (): void =>
+				{
+					isArray([], isNumberTest);
+				};
+
+				const WRAPPER_VALID = (): void =>
+				{
+					isArray([1, 2, 3], isNumberTest);
+				};
+
+				doesNotThrow(WRAPPER_EMPTY);
+				doesNotThrow(WRAPPER_VALID);
+			}
+		);
+
+		it(
+			"should throw when given an array with some values not passing the test constraint",
+			(): void =>
+			{
+				const WRAPPER = (): void =>
+				{
+					isArray([1, 2, 3, Symbol("anomaly")], isNumberTest);
 				};
 
 				throws(WRAPPER, testAggregateError);

--- a/packages/ts-predicate/test/TypeAssertion/isBigInt.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isBigInt.test.mts
@@ -1,28 +1,28 @@
-import { doesNotThrow, throws } from "node:assert";
+import { doesNotThrow, throws } from "assert";
 
 import { describe, it } from "node:test";
 
-import { isString } from "../../src/TypeAssertion/isString.mjs";
+import { isBigInt } from "../../src/TypeAssertion/isBigInt.mjs";
 
 import { BaseType, getInvertedValues, getValues } from "../common/getValues.mjs";
 
 import { testError } from "../common/testError.mjs";
 
 describe(
-	"TypeAssertion / isString",
+	"TypeAssertion / isBigInt",
 	(): void =>
 	{
 		it(
-			"should return when given a string",
+			"should return when given a big integer",
 			(): void =>
 			{
-				const VALUES: Array<unknown> = getValues(BaseType.STRING);
+				const VALUES: Array<unknown> = getValues(BaseType.BIG_INT);
 
 				for (const ITEM of VALUES)
 				{
 					const WRAPPER = (): void =>
 					{
-						isString(ITEM);
+						isBigInt(ITEM);
 					};
 
 					doesNotThrow(WRAPPER);
@@ -34,13 +34,13 @@ describe(
 			"should throw when given anything else",
 			(): void =>
 			{
-				const VALUES: Array<unknown> = getInvertedValues(BaseType.STRING);
+				const VALUES: Array<unknown> = getInvertedValues(BaseType.BIG_INT);
 
 				for (const ITEM of VALUES)
 				{
 					const WRAPPER = (): void =>
 					{
-						isString(ITEM);
+						isBigInt(ITEM);
 					};
 
 					throws(WRAPPER, testError);

--- a/packages/ts-predicate/test/TypeAssertion/isBoolean.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isBoolean.test.mts
@@ -8,7 +8,6 @@ import { BaseType, getInvertedValues, getValues } from "../common/getValues.mjs"
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isBoolean",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isCallable.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isCallable.test.mts
@@ -8,7 +8,6 @@ import { BaseType, getInvertedValues, getValues } from "../common/getValues.mjs"
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isCallable",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isDefined.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isDefined.test.mts
@@ -8,7 +8,6 @@ import { BaseType, getInvertedValues, getValues } from "../common/getValues.mjs"
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isDefined",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isFiniteNumber.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isFiniteNumber.test.mts
@@ -8,7 +8,6 @@ import { BaseType, GroupType, getInvertedValues, getValues } from "../common/get
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isFiniteNumber",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isFunction.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isFunction.test.mts
@@ -8,7 +8,6 @@ import { GroupType, getInvertedValues, getValues } from "../common/getValues.mjs
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isFunction",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isInteger.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isInteger.test.mts
@@ -8,7 +8,6 @@ import { BaseType, GroupType, getInvertedValues, getValues } from "../common/get
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isInteger",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isNumber.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isNumber.test.mts
@@ -8,7 +8,6 @@ import { GroupType, getInvertedValues, getValues } from "../common/getValues.mjs
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isNumber",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isObject.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isObject.test.mts
@@ -8,7 +8,6 @@ import { GroupType, getInvertedValues, getValues } from "../common/getValues.mjs
 
 import { testError } from "../common/testError.mjs";
 
-
 describe(
 	"TypeAssertion / isObject",
 	(): void =>

--- a/packages/ts-predicate/test/TypeAssertion/isPopulatedArray.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isPopulatedArray.test.mts
@@ -8,7 +8,6 @@ import { BaseType, getInvertedValues } from "../common/getValues.mjs";
 
 import { testError } from "../common/testError.mjs";
 
-
 function isNumberTest(value: unknown): value is number
 {
 	return Number.isSafeInteger(value);
@@ -115,6 +114,32 @@ describe(
 				const WRAPPER = (): void =>
 				{
 					isPopulatedArray([1, 2, 3, Symbol("anomaly")], { itemTest: isNumberTest });
+				};
+
+				throws(WRAPPER, testError);
+			}
+		);
+
+		it(
+			"should return when given an array with all the values passing the test constraint",
+			(): void =>
+			{
+				const WRAPPER = (): void =>
+				{
+					isPopulatedArray([1, 2, 3], isNumberTest);
+				};
+
+				doesNotThrow(WRAPPER);
+			}
+		);
+
+		it(
+			"should throw when given an array with some values not passing the test constraint",
+			(): void =>
+			{
+				const WRAPPER = (): void =>
+				{
+					isPopulatedArray([1, 2, 3, Symbol("anomaly")], isNumberTest);
 				};
 
 				throws(WRAPPER, testError);

--- a/packages/ts-predicate/test/TypeAssertion/isPrimitive.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isPrimitive.test.mts
@@ -4,10 +4,9 @@ import { describe, it } from "node:test";
 
 import { isPrimitive } from "../../src/TypeAssertion/isPrimitive.mjs";
 
-import { BaseType, GroupType, getInvertedValues, getValues } from "../common/getValues.mjs";
+import { GroupType, getInvertedValues, getValues } from "../common/getValues.mjs";
 
 import { testError } from "../common/testError.mjs";
-
 
 describe(
 	"TypeAssertion / isPrimitive",
@@ -17,7 +16,7 @@ describe(
 			"should return when given a primitive value",
 			(): void =>
 			{
-				const VALUES: Array<unknown> = getInvertedValues(BaseType.SYMBOL, GroupType.OBJECT, GroupType.FUNCTION_CLASS);
+				const VALUES: Array<unknown> = getValues(GroupType.PRIMITIVE);
 
 				for (const ITEM of VALUES)
 				{
@@ -35,7 +34,7 @@ describe(
 			"should throw when given a composite value",
 			(): void =>
 			{
-				const VALUES: Array<unknown> = getValues(BaseType.SYMBOL, GroupType.OBJECT, GroupType.FUNCTION_CLASS);
+				const VALUES: Array<unknown> = getInvertedValues(GroupType.PRIMITIVE);
 
 				for (const ITEM of VALUES)
 				{

--- a/packages/ts-predicate/test/TypeAssertion/isRecord.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isRecord.test.mts
@@ -72,6 +72,32 @@ describe(
 		);
 
 		it(
+			"should return when given a record with all the values passing the itemTest constraint",
+			(): void =>
+			{
+				const WRAPPER = (): void =>
+				{
+					isRecord({ a: 1, b: 2, c: 3 }, { itemTest: isNumberTest });
+				};
+
+				doesNotThrow(WRAPPER);
+			}
+		);
+
+		it(
+			"should throw when given a record with some values not passing the itemTest constraint",
+			(): void =>
+			{
+				const WRAPPER = (): void =>
+				{
+					isRecord({ a: 1, b: 2, c: Symbol("anomaly") }, { itemTest: isNumberTest });
+				};
+
+				throws(WRAPPER, testAggregateError);
+			}
+		);
+
+		it(
 			"should return when given a record with all the values passing the test constraint",
 			(): void =>
 			{

--- a/packages/ts-predicate/test/TypeGuard/isArray.test.mts
+++ b/packages/ts-predicate/test/TypeGuard/isArray.test.mts
@@ -90,5 +90,27 @@ describe(
 				strictEqual(RESULT, false);
 			}
 		);
+
+		it(
+			"should return true when given an array with all the values passing the test constraint",
+			(): void =>
+			{
+				const RESULT_EMPTY: unknown = isArray([], isNumberTest);
+				const RESULT_VALID: unknown = isArray([1, 2, 3], isNumberTest);
+
+				strictEqual(RESULT_EMPTY, true);
+				strictEqual(RESULT_VALID, true);
+			}
+		);
+
+		it(
+			"should return false when given an array with some values not passing the test constraint",
+			(): void =>
+			{
+				const RESULT: unknown = isArray([1, 2, 3, Symbol("anomaly")], isNumberTest);
+
+				strictEqual(RESULT, false);
+			}
+		);
 	}
 );

--- a/packages/ts-predicate/test/TypeGuard/isBigInt.test.mts
+++ b/packages/ts-predicate/test/TypeGuard/isBigInt.test.mts
@@ -1,0 +1,43 @@
+import { strictEqual } from "node:assert";
+
+import { describe, it } from "node:test";
+
+import { isBigInt } from "../../src/TypeGuard/isBigInt.mjs";
+
+import { BaseType, getInvertedValues, getValues } from "../common/getValues.mjs";
+
+describe(
+	"TypeGuard / isBigInt",
+	(): void =>
+	{
+		it(
+			"should return true when given a big integer",
+			(): void =>
+			{
+				const VALUES: Array<unknown> = getValues(BaseType.BIG_INT);
+
+				for (const ITEM of VALUES)
+				{
+					const RESULT: unknown = isBigInt(ITEM);
+
+					strictEqual(RESULT, true);
+				}
+			}
+		);
+
+		it(
+			"should return false when given anything else",
+			(): void =>
+			{
+				const VALUES: Array<unknown> = getInvertedValues(BaseType.BIG_INT);
+
+				for (const ITEM of VALUES)
+				{
+					const RESULT: unknown = isBigInt(ITEM);
+
+					strictEqual(RESULT, false);
+				}
+			}
+		);
+	}
+);

--- a/packages/ts-predicate/test/TypeGuard/isPopulatedArray.test.mts
+++ b/packages/ts-predicate/test/TypeGuard/isPopulatedArray.test.mts
@@ -91,5 +91,25 @@ describe(
 				strictEqual(RESULT, false);
 			}
 		);
+
+		it(
+			"should return true when given an array with all the values passing the test constraint",
+			(): void =>
+			{
+				const RESULT: unknown = isPopulatedArray([1, 2, 3], isNumberTest);
+
+				strictEqual(RESULT, true);
+			}
+		);
+
+		it(
+			"should return false when given an array with some values not passing the test constraint",
+			(): void =>
+			{
+				const RESULT: unknown = isPopulatedArray([1, 2, 3, Symbol("anomaly")], isNumberTest);
+
+				strictEqual(RESULT, false);
+			}
+		);
 	}
 );

--- a/packages/ts-predicate/test/TypeGuard/isPrimitive.test.mts
+++ b/packages/ts-predicate/test/TypeGuard/isPrimitive.test.mts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 
 import { isPrimitive } from "../../src/TypeGuard/isPrimitive.mjs";
 
-import { BaseType, GroupType, getInvertedValues, getValues } from "../common/getValues.mjs";
+import { GroupType, getInvertedValues, getValues } from "../common/getValues.mjs";
 
 describe(
 	"TypeGuard / isPrimitive",
@@ -14,7 +14,7 @@ describe(
 			"should return true when given a primitive value",
 			(): void =>
 			{
-				const VALUES: Array<unknown> = getInvertedValues(BaseType.SYMBOL, GroupType.OBJECT, GroupType.FUNCTION_CLASS);
+				const VALUES: Array<unknown> = getValues(GroupType.PRIMITIVE);
 
 				for (const ITEM of VALUES)
 				{
@@ -29,7 +29,7 @@ describe(
 			"should return false when given a composite value",
 			(): void =>
 			{
-				const VALUES: Array<unknown> = getValues(BaseType.SYMBOL, GroupType.OBJECT, GroupType.FUNCTION_CLASS);
+				const VALUES: Array<unknown> = getInvertedValues(GroupType.PRIMITIVE);
 
 				for (const ITEM of VALUES)
 				{

--- a/packages/ts-predicate/test/TypeGuard/isRecord.test.mts
+++ b/packages/ts-predicate/test/TypeGuard/isRecord.test.mts
@@ -61,6 +61,26 @@ describe(
 		);
 
 		it(
+			"should return true when given a record with all the values passing the itemTest constraint",
+			(): void =>
+			{
+				const RESULT: unknown = isRecord({ a: 1, b: 2, c: 3 }, { itemTest: isNumberTest });
+
+				strictEqual(RESULT, true);
+			}
+		);
+
+		it(
+			"should return false when given a record with some values not passing the itemTest constraint",
+			(): void =>
+			{
+				const RESULT: unknown = isRecord({ a: 1, b: 2, c: Symbol("anomaly") }, { itemTest: isNumberTest });
+
+				strictEqual(RESULT, false);
+			}
+		);
+
+		it(
 			"should return true when given a record with all the values passing the test constraint",
 			(): void =>
 			{

--- a/packages/ts-predicate/test/TypeHint/getBaseType.test.mts
+++ b/packages/ts-predicate/test/TypeHint/getBaseType.test.mts
@@ -85,6 +85,21 @@ describe(
 		);
 
 		it(
+			'should return "bigint" when given a big int',
+			(): void =>
+			{
+				strictEqual(getBaseType(BigInt(0)), "bigint");
+				strictEqual(getBaseType(BigInt(-0)), "bigint");
+				strictEqual(getBaseType(BigInt(1)), "bigint");
+				strictEqual(getBaseType(BigInt(-1)), "bigint");
+				strictEqual(getBaseType(BigInt(Number.MIN_SAFE_INTEGER + 4)), "bigint");
+				strictEqual(getBaseType(BigInt(Number.MAX_SAFE_INTEGER - 4)), "bigint");
+				strictEqual(getBaseType(BigInt(Number.MIN_SAFE_INTEGER - 4)), "bigint");
+				strictEqual(getBaseType(BigInt(Number.MAX_SAFE_INTEGER + 4)), "bigint");
+			}
+		);
+
+		it(
 			'should return "string" when given a string',
 			(): void =>
 			{

--- a/packages/ts-predicate/test/TypeHint/getDetailedType.test.mts
+++ b/packages/ts-predicate/test/TypeHint/getDetailedType.test.mts
@@ -75,7 +75,7 @@ describe(
 		);
 
 		it(
-			'should return "number" when given a number',
+			'should return "number (N)" when given a number',
 			(): void =>
 			{
 				strictEqual(getDetailedType(0), "number (0)");
@@ -92,6 +92,21 @@ describe(
 				strictEqual(getDetailedType(-Number.MAX_VALUE), "number (-1.7976931348623157e+308)");
 				strictEqual(getDetailedType(Number.POSITIVE_INFINITY), "number (Infinity)");
 				strictEqual(getDetailedType(Number.NEGATIVE_INFINITY), "number (-Infinity)");
+			}
+		);
+
+		it(
+			'should return "bigint (N)" when given a big int',
+			(): void =>
+			{
+				strictEqual(getDetailedType(BigInt(0)), "bigint (0)");
+				strictEqual(getDetailedType(BigInt(-0)), "bigint (0)");
+				strictEqual(getDetailedType(BigInt(1)), "bigint (1)");
+				strictEqual(getDetailedType(BigInt(-1)), "bigint (-1)");
+				strictEqual(getDetailedType(BigInt(Number.MIN_SAFE_INTEGER + 4)), "bigint (-9007199254740987)");
+				strictEqual(getDetailedType(BigInt(Number.MAX_SAFE_INTEGER - 4)), "bigint (9007199254740987)");
+				strictEqual(getDetailedType(BigInt(Number.MIN_SAFE_INTEGER - 4)), "bigint (-9007199254740996)");
+				strictEqual(getDetailedType(BigInt(Number.MAX_SAFE_INTEGER + 4)), "bigint (9007199254740996)");
 			}
 		);
 

--- a/packages/ts-predicate/test/common/getValues.mts
+++ b/packages/ts-predicate/test/common/getValues.mts
@@ -20,6 +20,20 @@ function expandTypes(types: Array<BaseType | GroupType>): Array<BaseType>
 	{
 		switch (TYPE)
 		{
+			case GroupType.PRIMITIVE:
+
+				TYPES.push(
+					BaseType.NULLISH,
+					BaseType.BOOLEAN,
+					BaseType.INTEGER,
+					BaseType.REAL,
+					BaseType.INFINITY,
+					BaseType.BIG_INT,
+					BaseType.STRING
+				);
+
+				break;
+
 			case GroupType.NUMBER:
 
 				TYPES.push(BaseType.INTEGER, BaseType.REAL, BaseType.INFINITY);
@@ -92,6 +106,18 @@ function getValuesForType(type: BaseType): Array<unknown>
 			return [
 				Number.POSITIVE_INFINITY,
 				Number.NEGATIVE_INFINITY,
+			];
+
+		case BaseType.BIG_INT:
+
+			return [
+				BigInt(0),
+				BigInt(1),
+				BigInt(-1),
+				BigInt(Number.MIN_SAFE_INTEGER + 4),
+				BigInt(Number.MAX_SAFE_INTEGER - 4),
+				BigInt(Number.MIN_SAFE_INTEGER - 4),
+				BigInt(Number.MAX_SAFE_INTEGER + 4),
 			];
 
 		case BaseType.STRING:
@@ -174,6 +200,7 @@ function getInvertedValues(...excluded_types: Array<BaseType | GroupType>): Arra
 		BaseType.INTEGER,
 		BaseType.REAL,
 		BaseType.INFINITY,
+		BaseType.BIG_INT,
 		BaseType.STRING,
 		BaseType.SYMBOL,
 		BaseType.ARRAY,

--- a/packages/ts-predicate/test/common/types/BaseType.mts
+++ b/packages/ts-predicate/test/common/types/BaseType.mts
@@ -4,6 +4,7 @@ const enum BaseType
 	BOOLEAN = "boolean",
 	INTEGER = "integer",
 	REAL = "real",
+	BIG_INT = "bigint",
 	INFINITY = "infinity",
 	STRING = "string",
 	SYMBOL = "symbol",

--- a/packages/ts-predicate/test/common/types/GroupType.mts
+++ b/packages/ts-predicate/test/common/types/GroupType.mts
@@ -1,9 +1,10 @@
 const enum GroupType
 {
-	FUNCTION_CLASS = "function-class",
+	PRIMITIVE = "primitive",
 	NUMBER = "number",
 	FINITE = "finite",
 	OBJECT = "object",
+	FUNCTION_CLASS = "function-class",
 }
 
 export { GroupType };


### PR DESCRIPTION
- [x] Support for bigint
  - [x] updated documentation
  - [x] added TypeAssertion / isBigint function
  - [x] updated TypeAssertion / isPrimitive
  - [x] added TypeGuard / isBigint function
  - [x] updated TypeGuard / isPrimitive
  - [x] updated Helpers / GetBaseType
  - [x] updated Helpers / GetDetailedType
- [x] Uniformisation of item testing
  - [x] updated documentation
  - [x] updated TypeAssertion / isArray
  - [x] updated TypeAssertion / isPopulatedArray
  - [x] updated TypeAssertion / isRecord
  - [x] updated TypeGuard / isArray
  - [x] updated TypeGuard / isPopulatedArray
  - [x] updated TypeGuard / isRecord
- [x] renamed Helpers -> Helper