### PR TITLE
finish mockingbird

### DIFF
--- a/packages/mockingbird/package.json
+++ b/packages/mockingbird/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "@vitruvius-lab/mock-module",
+	"name": "@vitruvius-lab/mockingbird",
 	"version": "0.1.0",
 	"description": "Module mocking library",
 	"author": "Benjamin Blum <benjamin.blum.98@gmail.com>",
 	"contributors": [
 		"Nicolas Cordier-Cerezo <nicolas.cordier@outlook.com>"
 	],
-	"homepage": "https://github.com/VitruviusLab/typescript/tree/main/packages/mock-module#readme",
+	"homepage": "https://github.com/VitruviusLab/typescript/tree/main/packages/mockingbird#readme",
 	"bugs": "https://github.com/VitruviusLab/typescript/issues",
 	"license": "MIT",
 	"repository": {
@@ -41,7 +41,10 @@
 		"eslint:check": "eslint ./src ./test",
 		"eslint:fix": "eslint ./src ./test --fix",
 		"test:unit": "pnpm test:unit:build && pnpm test:unit:run",
-		"test:unit:build": "tsc -p tsconfig.test.json",
+		"test:unit:build": "pnpm test:unit:clean && pnpm test:unit:compile && pnpm test:unit:post",
+		"test:unit:clean": "rm -rf ./tmp",
+		"test:unit:compile": "tsc -p tsconfig.test.json",
+		"test:unit:post": "cp -r ./test/dummy/ ./tmp/test-build/test/dummy",
 		"test:unit:run": "node --loader=./tmp/test-build/src/loader.mjs --test ./tmp/test-build/test",
 		"test:unit:coverage": "NODE_V8_COVERAGE=./reports/node-coverage node  --experimental-test-coverage --loader=./tmp/test-build/src/loader.mjs --test ./tmp/test-build/test",
 		"test:unit:stryker": "NODE_ENV=test TS_NODE_PROJECT=./tsconfig.stryker.json mocha --config .mocharc.stryker.json",

--- a/packages/mockingbird/src/loader.mts
+++ b/packages/mockingbird/src/loader.mts
@@ -10,7 +10,7 @@ import { decodeInfos } from "./utils/MockingInfos.mjs";
 
 import { buildCause } from "./utils/buildCause.mjs";
 
-import { resolveModuleIdentifier } from "./utils/resolveModuleIdentifier.mjs";
+import { convertSource } from "./utils/convertSource.mjs";
 
 import type { LoadContext } from "./Type/LoadContext.mjs";
 
@@ -47,7 +47,7 @@ async function load(module_identifier: string, context: LoadContext, next_load: 
 		return await next_load(module_identifier, context);
 	}
 
-	const INFOS: MockingInfos = decodeInfos(module_identifier);
+	const INFOS: MockingInfos = decodeInfos(module_identifier.slice(prefix.length));
 
 	let source: string | undefined = undefined;
 
@@ -60,53 +60,7 @@ async function load(module_identifier: string, context: LoadContext, next_load: 
 		throw new Error(`Unable to retrieve module ${INFOS.moduleIdentifier}.`, buildCause(error));
 	}
 
-	source = source.replaceAll(
-		/import\s*(?<imported_items>.+?)\s*from\s*['"](?<dependency_identifier>[^'"]+)['"]/g,
-		// @ts-expect-error: first parameter is unused
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars -- first parameter is unused
-		(match: string, imported_items: string, dependency_identifier: string): string =>
-		{
-			let absolute_dependency_identifier: string = resolveModuleIdentifier(dependency_identifier, INFOS.moduleIdentifier);
-
-			if (!INFOS.dependencyIdentifiers.includes(absolute_dependency_identifier))
-			{
-				if (absolute_dependency_identifier.startsWith("file://"))
-				{
-					absolute_dependency_identifier = fileURLToPath(absolute_dependency_identifier);
-				}
-
-				return `import ${imported_items} from "${absolute_dependency_identifier}";`;
-			}
-
-			let items: string = imported_items.trim();
-
-			if (items.startsWith("*"))
-			{
-				items = items.replace(/\*\s*as\s+/, "");
-			}
-			else if (!items.startsWith("{"))
-			{
-				items = `{ default: ${items} }`;
-			}
-			else if (/\bas\b/.test(items))
-			{
-				items = items.replaceAll(/\s+as\s+/g, ": ");
-			}
-
-			return `const ${items} = MockStorage.Get("${INFOS.token}_${absolute_dependency_identifier}")`;
-		}
-	);
-
-	const STORAGE_LIB: string = resolveModuleIdentifier("./utils/MockStorage.mjs", import.meta.url);
-	const MOCK_HEADER: string = `import { MockStorage } from "${STORAGE_LIB}";`;
-	const MOCK_CLEAN_UP: Array<string> = INFOS.dependencyIdentifiers.map(
-		(absolute_dependency_identifier: string): string =>
-		{
-			return `MockStorage.Remove("${INFOS.token}_${absolute_dependency_identifier}");`;
-		}
-	);
-
-	source = `${MOCK_HEADER}\n\n${source}\n${MOCK_CLEAN_UP.join("\n")}\n`;
+	source = convertSource(source, INFOS);
 
 	return {
 		shortCircuit: true,

--- a/packages/mockingbird/src/utils/MockingInfos.mts
+++ b/packages/mockingbird/src/utils/MockingInfos.mts
@@ -12,6 +12,17 @@ import type { MockedDependency } from "../Type/MockedDependency.mjs";
 
 import type { MockingInfos } from "../Type/MockingInfos.mjs";
 
+interface ConvertTextOptions
+{
+	from: BufferEncoding;
+	to: BufferEncoding;
+}
+
+function convertText(data: string, options: ConvertTextOptions): string
+{
+	return Buffer.from(data, options.from).toString(options.to);
+}
+
 function encodeInfos(module_identifier: string, meta_url: string, mocks: Record<string, MockedDependency>): string
 {
 	const TOKEN: string = randomUUID();
@@ -21,7 +32,7 @@ function encodeInfos(module_identifier: string, meta_url: string, mocks: Record<
 	Object.keys(mocks).forEach(
 		(dependency_identifier: string): void =>
 		{
-			const ABSOLUTE_DEPENDENCY_IDENTIFIER: string = resolveModuleIdentifier(dependency_identifier, meta_url);
+			const ABSOLUTE_DEPENDENCY_IDENTIFIER: string = resolveModuleIdentifier(dependency_identifier, ABSOLUTE_MODULE_IDENTIFIER);
 			const MOCKED_DEPENDENCY: unknown = mocks[dependency_identifier];
 
 			isMockedDependency(MOCKED_DEPENDENCY, dependency_identifier);
@@ -37,12 +48,16 @@ function encodeInfos(module_identifier: string, meta_url: string, mocks: Record<
 		dependencyIdentifiers: DEPENDENCY_IDENTIFIERS,
 	};
 
-	return Buffer.from(JSON.stringify(INFOS), "utf-8").toString("base64");
+	const JSON_ENCODED: string = JSON.stringify(INFOS);
+
+	return convertText(JSON_ENCODED, { from: "utf-8", to: "base64" });
 }
 
 function decodeInfos(data: string): MockingInfos
 {
-	const INFOS: unknown = JSON.parse(Buffer.from(data, "base64").toString("utf-8"));
+	const JSON_ENCODED: string = convertText(data, { from: "base64", to: "utf-8" });
+
+	const INFOS: unknown = JSON.parse(JSON_ENCODED);
 
 	isMockingInfos(INFOS);
 

--- a/packages/mockingbird/src/utils/convertSource.mts
+++ b/packages/mockingbird/src/utils/convertSource.mts
@@ -1,0 +1,62 @@
+import { fileURLToPath } from "node:url";
+
+import { resolveModuleIdentifier } from "./resolveModuleIdentifier.mjs";
+
+import type { MockingInfos } from "../Type/MockingInfos.mjs";
+
+function convertSource(source: string, infos: MockingInfos): string
+{
+	let modified_source: string = source;
+
+	modified_source = modified_source.replaceAll(
+		/import\s*(?<imported_items>.+?)\s*from\s*['"](?<dependency_identifier>[^'"]+)['"]/g,
+		// @ts-expect-error: first parameter is unused
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars -- first parameter is unused
+		(match: string, imported_items: string, dependency_identifier: string): string =>
+		{
+			let absolute_dependency_identifier: string = resolveModuleIdentifier(dependency_identifier, infos.moduleIdentifier);
+
+			if (!infos.dependencyIdentifiers.includes(absolute_dependency_identifier))
+			{
+				if (absolute_dependency_identifier.startsWith("file://"))
+				{
+					absolute_dependency_identifier = fileURLToPath(absolute_dependency_identifier);
+				}
+
+				return `import ${imported_items} from "${absolute_dependency_identifier}";`;
+			}
+
+			let items: string = imported_items.trim();
+
+			if (items.startsWith("*"))
+			{
+				items = items.replace(/\*\s*as\s+/, "");
+			}
+			else if (!items.startsWith("{"))
+			{
+				items = `{ default: ${items} }`;
+			}
+			else if (/\bas\b/.test(items))
+			{
+				items = items.replaceAll(/\s+as\s+/g, ": ");
+			}
+
+			return `const ${items} = MockStorage.Get("${infos.token}_${absolute_dependency_identifier}")`;
+		}
+	);
+
+	const STORAGE_LIB: string = resolveModuleIdentifier("./MockStorage.mjs", import.meta.url);
+	const MOCK_HEADER: string = `import { MockStorage } from "${STORAGE_LIB}";`;
+	const MOCK_CLEAN_UP: Array<string> = infos.dependencyIdentifiers.map(
+		(absolute_dependency_identifier: string): string =>
+		{
+			return `MockStorage.Remove("${infos.token}_${absolute_dependency_identifier}");`;
+		}
+	);
+
+	modified_source = `${MOCK_HEADER}\n\n${modified_source}\n${MOCK_CLEAN_UP.join("\n")}\n`;
+
+	return modified_source;
+}
+
+export { convertSource };

--- a/packages/mockingbird/src/utils/resolveModuleIdentifier.mts
+++ b/packages/mockingbird/src/utils/resolveModuleIdentifier.mts
@@ -1,7 +1,6 @@
 function resolveModuleIdentifier(specifier: string, meta_url: string): string
 {
 	return (new URL(specifier, meta_url)).href;
-	// return import.meta.resolve(specifier, meta_url);
 }
 
 export { resolveModuleIdentifier };

--- a/packages/mockingbird/test/dummy/dummy-dependency.mjs
+++ b/packages/mockingbird/test/dummy/dummy-dependency.mjs
@@ -1,6 +1,6 @@
 function dummyDependency(input)
 {
-	return input.replaceAll(/\D/);
+	return input.replaceAll(/\D/g, "");
 }
 
 export { dummyDependency };

--- a/packages/mockingbird/test/dummy/dummy-lib.mjs
+++ b/packages/mockingbird/test/dummy/dummy-lib.mjs
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { dummyDependency } from "./dummyDependency.mjs";
+import { dummyDependency } from "./dummy-dependency.mjs";
 
 function dummy()
 {

--- a/packages/mockingbird/test/mockingbird.test.mts
+++ b/packages/mockingbird/test/mockingbird.test.mts
@@ -1,6 +1,6 @@
-import { doesNotThrow, strictEqual } from "assert";
+import { doesNotThrow, strictEqual } from "node:assert";
 
-import { describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 
 import { mockingbird } from "../src/mockingbird.mjs";
 
@@ -11,6 +11,22 @@ describe(
 	"mockingbird",
 	(): void =>
 	{
+		let keepAlive: NodeJS.Timer | undefined = undefined;
+
+		before(
+			(): void =>
+			{
+				keepAlive = setInterval((): void => { }, 100_000);
+			}
+		);
+
+		after(
+			(): void =>
+			{
+				clearInterval(keepAlive);
+			}
+		);
+
 		it(
 			"should be able to mock a dummy lib that has a module dependency",
 			async (): Promise<void> =>
@@ -27,7 +43,7 @@ describe(
 								return UUID;
 							}
 						},
-						"./dummyDependency.mjs": {
+						"./dummy-dependency.mjs": {
 							dummyDependency: (input: string): string =>
 							{
 								return input;

--- a/packages/mockingbird/test/utils/MockingInfos.test.mts
+++ b/packages/mockingbird/test/utils/MockingInfos.test.mts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual, throws } from "assert";
+import { deepStrictEqual, strictEqual, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/mockingbird/test/utils/convertSource.test.mts
+++ b/packages/mockingbird/test/utils/convertSource.test.mts
@@ -1,0 +1,168 @@
+import { match, strictEqual } from "node:assert";
+
+import { describe, it } from "node:test";
+
+import { convertSource } from "../../src/utils/convertSource.mjs";
+
+import type { MockingInfos } from "../../src/Type/MockingInfos.mjs";
+
+describe(
+	"convertSource",
+	(): void =>
+	{
+		it(
+			"should prepend an import of the MockStorage module",
+			(): void =>
+			{
+				const SOURCE: string = "";
+
+				const INFOS: MockingInfos = {
+					token: "token",
+					moduleIdentifier: "file:/module.mjs",
+					dependencyIdentifiers: [],
+				};
+
+				const RESULT: unknown = convertSource(SOURCE, INFOS);
+
+				if (typeof RESULT !== "string")
+				{
+					strictEqual(typeof RESULT, "string", "Return value must be a string");
+
+					return;
+				}
+
+				match(RESULT, /\bimport \{ MockStorage \} from ".*\/MockStorage\.mjs";/);
+			}
+		);
+
+		it(
+			"should replace mocked dependencies.",
+			(): void =>
+			{
+				const SOURCE: string = `
+					import { randomUUID } from "node:crypto";
+					import { foo } from "file:/foo.mjs";
+
+					function test()
+					{
+						return randomUUID();
+					}
+
+					export { test, foo };
+				`;
+
+				const INFOS: MockingInfos = {
+					token: "12345",
+					moduleIdentifier: "file:///module.mjs",
+					dependencyIdentifiers: ["node:crypto", "file:///foo.mjs"],
+				};
+
+				const RESULT: unknown = convertSource(SOURCE, INFOS);
+
+				if (typeof RESULT !== "string")
+				{
+					strictEqual(typeof RESULT, "string", "Return value must be a string");
+
+					return;
+				}
+
+				match(RESULT, /\bconst \{ randomUUID \} = MockStorage.Get\("12345_node:crypto"\);/);
+				match(RESULT, /\bconst \{ foo \} = MockStorage.Get\("12345_file:\/\/\/foo.mjs"\);/);
+			}
+		);
+
+		it(
+			"should ignore non-mocked dependencies.",
+			(): void =>
+			{
+				const SOURCE: string = `
+					import { randomUUID } from "node:crypto";
+
+					function test()
+					{
+						return randomUUID();
+					}
+
+					export { test };
+				`;
+
+				const INFOS: MockingInfos = {
+					token: "12345",
+					moduleIdentifier: "file:/module.mjs",
+					dependencyIdentifiers: [],
+				};
+
+				const RESULT: unknown = convertSource(SOURCE, INFOS);
+
+				if (typeof RESULT !== "string")
+				{
+					strictEqual(typeof RESULT, "string", "Return value must be a string");
+
+					return;
+				}
+
+				match(RESULT, /\bimport \{ randomUUID \} from "node:crypto";/);
+			}
+		);
+
+		it(
+			"should replace non-mocked dependencies relative path to the corresponding absolute path.",
+			(): void =>
+			{
+				const SOURCE: string = `
+					import { bar } from "./bar.mjs";
+
+					function test()
+					{
+						bar();
+					}
+
+					export { test };
+				`;
+
+				const INFOS: MockingInfos = {
+					token: "12345",
+					moduleIdentifier: "file:/module.mjs",
+					dependencyIdentifiers: [],
+				};
+
+				const RESULT: unknown = convertSource(SOURCE, INFOS);
+
+				if (typeof RESULT !== "string")
+				{
+					strictEqual(typeof RESULT, "string", "Return value must be a string");
+
+					return;
+				}
+
+				match(RESULT, /\bimport \{ bar \} from "\/bar.mjs";/);
+			}
+		);
+
+		it(
+			"should append code that clear the storage from the mocks",
+			(): void =>
+			{
+				const SOURCE: string = ``;
+
+				const INFOS: MockingInfos = {
+					token: "12345",
+					moduleIdentifier: "file:/module.mjs",
+					dependencyIdentifiers: ["node:crypto", "file:///foo.mjs"],
+				};
+
+				const RESULT: unknown = convertSource(SOURCE, INFOS);
+
+				if (typeof RESULT !== "string")
+				{
+					strictEqual(typeof RESULT, "string", "Return value must be a string");
+
+					return;
+				}
+
+				match(RESULT, /\bMockStorage.Remove\("12345_node:crypto"\);/);
+				match(RESULT, /\bMockStorage.Remove\("12345_file:\/\/\/foo.mjs"\);/);
+			}
+		);
+	}
+);

--- a/packages/mockingbird/test/utils/mockStorage.test.mts
+++ b/packages/mockingbird/test/utils/mockStorage.test.mts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, doesNotThrow, throws } from "assert";
+import { deepStrictEqual, doesNotThrow, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-lab/ts-predicate",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "TypeScript predicates library",
 	"author": "Benjamin Blum <benjamin.blum.98@gmail.com>",
 	"contributors": [

--- a/packages/ts-predicate/test/TypeAssertion/isArray.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isArray.test.mts
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "assert";
+import { doesNotThrow, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/test/TypeAssertion/isBigInt.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isBigInt.test.mts
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "assert";
+import { doesNotThrow, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/test/TypeAssertion/isBoolean.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isBoolean.test.mts
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "assert";
+import { doesNotThrow, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/test/TypeAssertion/isCallable.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isCallable.test.mts
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "assert";
+import { doesNotThrow, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/test/TypeAssertion/isInteger.test.mts
+++ b/packages/ts-predicate/test/TypeAssertion/isInteger.test.mts
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "assert";
+import { doesNotThrow, throws } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/test/TypeGuard/isArray.test.mts
+++ b/packages/ts-predicate/test/TypeGuard/isArray.test.mts
@@ -1,4 +1,4 @@
-import { strictEqual } from "assert";
+import { strictEqual } from "node:assert";
 
 import { describe, it } from "node:test";
 

--- a/packages/ts-predicate/test/TypeHint/getBaseType.test.mts
+++ b/packages/ts-predicate/test/TypeHint/getBaseType.test.mts
@@ -1,4 +1,4 @@
-import { strictEqual } from "assert";
+import { strictEqual } from "node:assert";
 
 import { describe, it } from "node:test";
 


### PR DESCRIPTION
* [x] fix name "mockingbird" in package.json
* [x] fix imports of node core modules without the `node:` prefix (impact ts-predicate too)
* [x] fix bugs
  * [x] test build: copy dummy files
  * [x] mock infos decoding
  * [x] path resolution
  * [x] dummy file names
* [x] move source code alteration to its own function, with unit tests
* [x] more readable text conversion between utf-8 <-> base64